### PR TITLE
Potential fix for code scanning alert no. 5: Incomplete string escaping or encoding

### DIFF
--- a/staticfiles/cloudinary/js/jquery.cloudinary.js
+++ b/staticfiles/cloudinary/js/jquery.cloudinary.js
@@ -4723,7 +4723,7 @@ var slice = [].slice,
       if (Util.isPlainObject(value)) {
         upload_params[key] = jQuery.map(value, function(v, k) {
           if (Util.isString(v)) {
-            v = v.replace(/[\|=]/g, "\\$&");
+            v = v.replace(/[\\|=]/g, "\\$&");
           }
           return k + '=' + v;
         }).join('|');


### PR DESCRIPTION
Potential fix for [https://github.com/unmatched78/note-learnI/security/code-scanning/5](https://github.com/unmatched78/note-learnI/security/code-scanning/5)

To fix the issue, we need to ensure that backslashes are escaped in addition to the `|` and `=` characters. This can be achieved by modifying the `replace` method to include backslashes in the regular expression. Specifically, we should use a regular expression that matches all three characters (`\`, `|`, and `=`) and escape them with a backslash.

The updated code will use the regular expression `/[\\|=]/g` to match all occurrences of these characters globally and replace them with their escaped versions.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
