### PR TITLE
Potential fix for code scanning alert no. 6: Information exposure through an exception

### DIFF
--- a/core/auth/webhooks.py
+++ b/core/auth/webhooks.py
@@ -89,7 +89,7 @@ def clerk_webhook(request):
 
         except Exception as exc:
             logger.exception("Error handling user.created webhook: %s", exc)
-            return HttpResponseServerError(str(exc))
+            return HttpResponseServerError("An internal error has occurred.")
 
     # Ignore other event types
     logger.debug("Ignoring Clerk event type: %s", event_type)


### PR DESCRIPTION
Potential fix for [https://github.com/unmatched78/Note-LearnI/security/code-scanning/6](https://github.com/unmatched78/Note-LearnI/security/code-scanning/6)

To fix the problem, we should avoid returning the exception message (`str(exc)`) in the HTTP response to the client. Instead, we should return a generic error message such as "An internal error has occurred" or simply use the default 500 error message. The detailed exception information should continue to be logged on the server using `logger.exception`, which is already present. The change should be made only to the line that returns the HTTP 500 response in the exception handler for the "user.created" event in the `clerk_webhook` view, specifically replacing `str(exc)` with a generic message.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
